### PR TITLE
Upgrade JUnit from 5.11.4 to 5.12.2 in standalone projects

### DIFF
--- a/1.01-starting-project-solutions/section-02-junit-review/1.01-project-solution-assert-equals-not-equals-AND-null-not-null/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.01-project-solution-assert-equals-not-equals-AND-null-not-null/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.02-project-solution-lifecycle-methods/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.02-project-solution-lifecycle-methods/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.03-project-solution-custom-display-name/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.03-project-solution-custom-display-name/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.04-project-solution-assert-same-not-same-AND-true-false/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.04-project-solution-assert-same-not-same-AND-true-false/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.05-project-solution-assert-array-iterable-lines/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.05-project-solution-assert-array-iterable-lines/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.06-project-solution-assert-throws-and-timeouts/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.06-project-solution-assert-throws-and-timeouts/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.07-project-solution-order-tests/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.07-project-solution-order-tests/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.08-project-solution-unit-test-reports-and-code-coverage-reports-with-intellij/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.08-project-solution-unit-test-reports-and-code-coverage-reports-with-intellij/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.09-project-solution-unit-test-reports-and-code-coverage-reports-with-maven/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.09-project-solution-unit-test-reports-and-code-coverage-reports-with-maven/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.01-starting-project-solutions/section-02-junit-review/1.10-project-solution-conditional-tests/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.10-project-solution-conditional-tests/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/01-fizzbuzz-project-solution-basic/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.11.4</version>
+            <version>5.12.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/compile-junit-projects.sh
+++ b/compile-junit-projects.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+set -e
+
+echo "=== Compiling JUnit Standalone Projects ==="
+echo ""
+
+FAILED_PROJECTS=()
+SUCCESSFUL_PROJECTS=()
+TOTAL_PROJECTS=0
+
+# Function to compile a project
+compile_project() {
+    local project_dir="$1"
+    local project_name=$(basename "$project_dir")
+
+    if [ -f "$project_dir/pom.xml" ]; then
+        TOTAL_PROJECTS=$((TOTAL_PROJECTS + 1))
+        echo "[$TOTAL_PROJECTS] Compiling: $project_name"
+        echo "    Path: $project_dir"
+
+        cd "$project_dir"
+        if mvn clean compile -Dmaven.compiler.showDeprecation=true -Dmaven.compiler.showWarnings=true 2>&1 | tee compile.log; then
+            SUCCESSFUL_PROJECTS+=("$project_name")
+            echo "    ✓ SUCCESS"
+        else
+            FAILED_PROJECTS+=("$project_name")
+            echo "    ✗ FAILED"
+        fi
+        cd - > /dev/null
+        echo ""
+    fi
+}
+
+# Save current directory
+START_DIR=$(pwd)
+
+# Section 1.00 - Starting project (no dependencies yet)
+if [ -d "1.00-starting-project" ]; then
+    compile_project "1.00-starting-project"
+fi
+
+# Section 1.01 - JUnit Review solutions
+if [ -d "1.01-starting-project-solutions/section-02-junit-review" ]; then
+    for dir in 1.01-starting-project-solutions/section-02-junit-review/*/; do
+        compile_project "$dir"
+    done
+fi
+
+# Section 1.12 - FizzBuzz TDD solutions
+if [ -d "1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd" ]; then
+    for dir in 1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/*/; do
+        compile_project "$dir"
+    done
+fi
+
+# Return to starting directory
+cd "$START_DIR"
+
+# Summary
+echo "========================================"
+echo "COMPILATION SUMMARY"
+echo "========================================"
+echo "Total JUnit projects compiled: $TOTAL_PROJECTS"
+echo "Successful: ${#SUCCESSFUL_PROJECTS[@]}"
+echo "Failed: ${#FAILED_PROJECTS[@]}"
+echo ""
+
+if [ ${#FAILED_PROJECTS[@]} -gt 0 ]; then
+    echo "FAILED PROJECTS:"
+    for project in "${FAILED_PROJECTS[@]}"; do
+        echo "  - $project"
+    done
+    echo ""
+    exit 1
+else
+    echo "✓ ALL JUNIT PROJECTS COMPILED SUCCESSFULLY!"
+fi

--- a/test-junit-projects.sh
+++ b/test-junit-projects.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+set -e
+
+echo "=== Running Unit Tests on JUnit Standalone Projects ==="
+echo ""
+
+FAILED_PROJECTS=()
+SUCCESSFUL_PROJECTS=()
+TOTAL_PROJECTS=0
+TOTAL_TESTS=0
+
+# Function to test a project
+test_project() {
+    local project_dir="$1"
+    local project_name=$(basename "$project_dir")
+
+    if [ -f "$project_dir/pom.xml" ]; then
+        TOTAL_PROJECTS=$((TOTAL_PROJECTS + 1))
+        echo "[$TOTAL_PROJECTS] Testing: $project_name"
+        echo "    Path: $project_dir"
+
+        cd "$project_dir"
+        if mvn clean test 2>&1 | tee test.log; then
+            SUCCESSFUL_PROJECTS+=("$project_name")
+            # Count tests from output (macOS compatible)
+            TEST_COUNT=$(grep "Tests run:" test.log | tail -1 | sed -n 's/.*Tests run: \([0-9]*\).*/\1/p' || echo "0")
+            if [ -n "$TEST_COUNT" ] && [ "$TEST_COUNT" != "0" ]; then
+                TOTAL_TESTS=$((TOTAL_TESTS + TEST_COUNT))
+                echo "    ✓ SUCCESS ($TEST_COUNT tests)"
+            else
+                echo "    ✓ SUCCESS"
+            fi
+        else
+            FAILED_PROJECTS+=("$project_name")
+            echo "    ✗ FAILED"
+            # Try to extract failure info
+            grep -A 5 "FAILURE" test.log || true
+        fi
+        cd - > /dev/null
+        echo ""
+    fi
+}
+
+# Save current directory
+START_DIR=$(pwd)
+
+# Section 1.00 - Starting project (no tests yet)
+if [ -d "1.00-starting-project" ]; then
+    test_project "1.00-starting-project"
+fi
+
+# Section 1.01 - JUnit Review solutions
+if [ -d "1.01-starting-project-solutions/section-02-junit-review" ]; then
+    for dir in 1.01-starting-project-solutions/section-02-junit-review/*/; do
+        test_project "$dir"
+    done
+fi
+
+# Section 1.12 - FizzBuzz TDD solutions
+if [ -d "1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd" ]; then
+    for dir in 1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/*/; do
+        test_project "$dir"
+    done
+fi
+
+# Return to starting directory
+cd "$START_DIR"
+
+# Summary
+echo "========================================"
+echo "TEST SUMMARY"
+echo "========================================"
+echo "Total JUnit projects tested: $TOTAL_PROJECTS"
+echo "Successful: ${#SUCCESSFUL_PROJECTS[@]}"
+echo "Failed: ${#FAILED_PROJECTS[@]}"
+echo "Total tests executed: $TOTAL_TESTS"
+echo ""
+
+if [ ${#FAILED_PROJECTS[@]} -gt 0 ]; then
+    echo "FAILED PROJECTS:"
+    for project in "${FAILED_PROJECTS[@]}"; do
+        echo "  - $project"
+    done
+    echo ""
+    exit 1
+else
+    echo "✓ ALL JUNIT PROJECT TESTS PASSED!"
+    echo "✓ $TOTAL_TESTS tests executed successfully across all JUnit projects"
+fi

--- a/update-junit-versions.sh
+++ b/update-junit-versions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+echo "Updating JUnit versions in standalone projects..."
+echo ""
+
+UPDATED_COUNT=0
+
+# Update JUnit version in section 1.01 projects
+find ./1.01-starting-project-solutions/section-02-junit-review -name "pom.xml" -type f | while IFS= read -r file; do
+  if grep -q "<version>5.11.4</version>" "$file"; then
+    sed -i.bak 's/<version>5\.11\.4<\/version>/<version>5.12.2<\/version>/g' "$file"
+    rm "${file}.bak"
+    echo "Updated: $file"
+    UPDATED_COUNT=$((UPDATED_COUNT + 1))
+  fi
+done
+
+# Update JUnit version in section 1.12 projects
+find ./1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd -name "pom.xml" -type f | while IFS= read -r file; do
+  if grep -q "<version>5.11.4</version>" "$file"; then
+    sed -i.bak 's/<version>5\.11\.4<\/version>/<version>5.12.2<\/version>/g' "$file"
+    rm "${file}.bak"
+    echo "Updated: $file"
+    UPDATED_COUNT=$((UPDATED_COUNT + 1))
+  fi
+done
+
+echo ""
+echo "Completed updating JUnit versions"


### PR DESCRIPTION
## Summary
Upgrades JUnit Jupiter from version 5.11.4 to 5.12.2 in all standalone JUnit projects.

## Changes
Updated junit-jupiter version in 13 standalone project pom.xml files
* Sections 1.01 (JUnit Review Solutions): 10 projects
* Section 1.12 (FizzBuzz TDD Solutions): 3 projects

## Scope
* Included: Pure JUnit projects in sections 1.x only
* Excluded: All Spring Boot projects (sections 2.x, 3.x, 4.x) use managed dependencies

## Testing
* All 14 JUnit standalone projects compiled successfully
* All JUnit standalone projects passed their unit tests
* Verified Spring Boot projects were not modified

## Compatibility
* Java 23 compatibility maintained
* No code changes required for this patch version upgrade
* No breaking changes in JUnit 5.12.2