### PR TITLE
Upgrade Java from 23 to 25 in all Maven projects

### DIFF
--- a/1.00-starting-project/pom.xml
+++ b/1.00-starting-project/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
 </project>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.01-project-solution-assert-equals-not-equals-AND-null-not-null/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.01-project-solution-assert-equals-not-equals-AND-null-not-null/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.02-project-solution-lifecycle-methods/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.02-project-solution-lifecycle-methods/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.03-project-solution-custom-display-name/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.03-project-solution-custom-display-name/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.04-project-solution-assert-same-not-same-AND-true-false/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.04-project-solution-assert-same-not-same-AND-true-false/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.05-project-solution-assert-array-iterable-lines/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.05-project-solution-assert-array-iterable-lines/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.06-project-solution-assert-throws-and-timeouts/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.06-project-solution-assert-throws-and-timeouts/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.07-project-solution-order-tests/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.07-project-solution-order-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.08-project-solution-unit-test-reports-and-code-coverage-reports-with-intellij/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.08-project-solution-unit-test-reports-and-code-coverage-reports-with-intellij/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.09-project-solution-unit-test-reports-and-code-coverage-reports-with-maven/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.09-project-solution-unit-test-reports-and-code-coverage-reports-with-maven/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
 
                 <executions>
                     <execution>

--- a/1.01-starting-project-solutions/section-02-junit-review/1.10-project-solution-conditional-tests/pom.xml
+++ b/1.01-starting-project-solutions/section-02-junit-review/1.10-project-solution-conditional-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
 
                 <executions>
                     <execution>

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/01-fizzbuzz-project-solution-basic/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/01-fizzbuzz-project-solution-basic/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
 
                 <executions>
                     <execution>

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/02-fizzbuzz-project-solution-parameterized-tests/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
 
                 <executions>
                     <execution>

--- a/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/03-fizzbuzz-project-solution-main-app/pom.xml
+++ b/1.12-fizzbuzz-project-solutions/section-03-test-driven-development-tdd/03-fizzbuzz-project-solution-main-app/pom.xml
@@ -9,8 +9,8 @@
     <version>1.0</version>
 
     <properties>
-        <maven.compiler.source>23</maven.compiler.source>
-        <maven.compiler.target>23</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.12</version>
+                <version>0.8.13</version>
 
                 <executions>
                     <execution>

--- a/2.00-starting-project/pom.xml
+++ b/2.00-starting-project/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/2.01-starting-project-solutions/section-04-spring-boot-unit-testing-support/2.01-solution-junit-assertions/pom.xml
+++ b/2.01-starting-project-solutions/section-04-spring-boot-unit-testing-support/2.01-solution-junit-assertions/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/2.20-starting-project/pom.xml
+++ b/2.20-starting-project/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/2.21-starting-project-solutions/section-05-unit-testing-mocking-with-mockito/pom.xml
+++ b/2.21-starting-project-solutions/section-05-unit-testing-mocking-with-mockito/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.00-starting-project/pom.xml
+++ b/3.00-starting-project/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-01-solution-create-student-service-test/pom.xml
+++ b/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-01-solution-create-student-service-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-02-solution-check-if-student-is-null-test/pom.xml
+++ b/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-02-solution-check-if-student-is-null-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-03-solution-delete-student-service-test/pom.xml
+++ b/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-03-solution-delete-student-service-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-04-solution-get-gradebook-test/pom.xml
+++ b/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-04-solution-get-gradebook-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-05-solution-sql-annotation-get-gradebook-test/pom.xml
+++ b/3.01-starting-project-solutions/section-07-testing-spring-boot-mvc-web-apps-database-integration-testing/3.01-05-solution-sql-annotation-get-gradebook-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-06-solution-gradebookcontroller-test-iterable-equals/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-06-solution-gradebookcontroller-test-iterable-equals/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-07-solution-gradebookcontroller-add-mvc-test/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-07-solution-gradebookcontroller-add-mvc-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-08-solution-create-student-http-post-request-test/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-08-solution-create-student-http-post-request-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-09-solution-create-student-http-request-when-added/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-09-solution-create-student-http-request-when-added/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-10-solution-update-index-html-to-handle-create-and-get-students/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-10-solution-update-index-html-to-handle-create-and-get-students/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-11-solution-delete-student-http-added/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-11-solution-delete-student-http-added/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-12-solution-delete-student-http-error-page/pom.xml
+++ b/3.01-starting-project-solutions/section-08-testing-spring-boot-mvc-web-apps-mvc-controller-testing/3.01-12-solution-delete-student-http-error-page/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-13-solution-create-grade-service-passed-for-math-grades/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-13-solution-create-grade-service-passed-for-math-grades/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-14-solution-create-grade-service-passed-for-science-grades/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-14-solution-create-grade-service-passed-for-science-grades/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-15-solution-create-grade-service-passed-for-history-grades/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-15-solution-create-grade-service-passed-for-history-grades/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-16-solution-create-grade-service-returns-false/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-16-solution-create-grade-service-returns-false/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-17-solution-add-math-science-history-grades-to-before-and-after/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-17-solution-add-math-science-history-grades-to-before-and-after/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-18-solution-edit-create-grade-service-to-use-collections/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-18-solution-edit-create-grade-service-to-use-collections/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-19-solution-delete-grade-math-service-only/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-19-solution-delete-grade-math-service-only/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-20-solution-delete-grade-science-and-history/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-20-solution-delete-grade-science-and-history/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-21-solution-delete-grade-science-return-student-id-zero/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-21-solution-delete-grade-science-return-student-id-zero/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-22-solution-enhance-delete-student-service-to-now-delete-grades/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-22-solution-enhance-delete-student-service-to-now-delete-grades/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-23-solution-student-information-service-test-pass/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-23-solution-student-information-service-test-pass/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-24-solution-student-information-return-null-for-invalid-student-id/pom.xml
+++ b/3.01-starting-project-solutions/section-09-testing-spring-boot-mvc-web-apps-gradebook-app-student-grades/3.01-24-solution-student-information-return-null-for-invalid-student-id/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-10-testing-spring-boot-mvc-web-apps-setup-sql-scripts-in-properties-files/3.01-25-solution-setup-sql-scripts-in-application-props-file-and-student-service/pom.xml
+++ b/3.01-starting-project-solutions/section-10-testing-spring-boot-mvc-web-apps-setup-sql-scripts-in-properties-files/3.01-25-solution-setup-sql-scripts-in-application-props-file-and-student-service/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-10-testing-spring-boot-mvc-web-apps-setup-sql-scripts-in-properties-files/3.01-26-solution-setup-sql-scripts-for-gradebook-controller-test/pom.xml
+++ b/3.01-starting-project-solutions/section-10-testing-spring-boot-mvc-web-apps-setup-sql-scripts-in-properties-files/3.01-26-solution-setup-sql-scripts-for-gradebook-controller-test/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-27-solution-enhance-student-information-method-on-grade-book-controller/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-27-solution-enhance-student-information-method-on-grade-book-controller/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-28-solution-create-grade-on-grade-book-controller/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-28-solution-create-grade-on-grade-book-controller/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-29-solution-enhance-and-refactor-configure-student-information-model/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-29-solution-enhance-and-refactor-configure-student-information-model/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-30-solution-create-a-valid-grade-http-request-student-does-not-exist/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-30-solution-create-a-valid-grade-http-request-student-does-not-exist/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-31-solution-create-an-invalid-grade-http-request-grade-type-does-not-exist/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-31-solution-create-an-invalid-grade-http-request-grade-type-does-not-exist/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-32-solution-delete-a-valid-grade-http-request/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-32-solution-delete-a-valid-grade-http-request/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-33-solution-delete-a-valid-grade-http-request-grade-id-does-not-exist/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-33-solution-delete-a-valid-grade-http-request-grade-id-does-not-exist/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-34-solution-delete-a-non-valid-grade-http-request/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-34-solution-delete-a-non-valid-grade-http-request/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-35-solution-update-student-information-thymeleaf-template-to-use-dynamic-data/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-35-solution-update-student-information-thymeleaf-template-to-use-dynamic-data/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-36-solution-create-application-test-properties-file/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-36-solution-create-application-test-properties-file/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-37-solution-update-app-to-connect-to-mysql/pom.xml
+++ b/3.01-starting-project-solutions/section-11-testing-spring-boot-mvc-web-apps-student-information-and-grades/3.01-37-solution-update-app-to-connect-to-mysql/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>war</packaging>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.00-starting-project/pom.xml
+++ b/4.00-starting-project/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-01-setting-up-gradebook-controller-test/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-01-setting-up-gradebook-controller-test/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-02-get-students-test/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-02-get-students-test/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-03-create-student/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-03-create-student/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-04-delete-student/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-04-delete-student/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-05-delete-student-error-page/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-05-delete-student-error-page/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-06-student-information-created/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-06-student-information-created/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-07-student-information-student-not-found/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-07-student-information-student-not-found/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-08-create-a-valid-grade/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-08-create-a-valid-grade/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-09-create-a-valid-student-id-does-not-exist/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-09-create-a-valid-student-id-does-not-exist/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-10-create-an-invalid-grade-the-grade-type-does-not-exist/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-10-create-an-invalid-grade-the-grade-type-does-not-exist/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-11-delete-a-valid-grade/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-11-delete-a-valid-grade/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-12-delete-a-valid-grade-the-grade-id-does-not-exist/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-12-delete-a-valid-grade-the-grade-id-does-not-exist/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 

--- a/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-13-delete-a-invalid-grade-the-grade-type-does-not-exist/pom.xml
+++ b/4.01-starting-project-solutions/section-12-testing-spring-boot-rest-apis/solution-4.01-13-delete-a-invalid-grade-the-grade-type-does-not-exist/pom.xml
@@ -15,7 +15,7 @@
 	<version>1.0.0</version>
 
 	<properties>
-		<java.version>23</java.version>
+		<java.version>25</java.version>
 		<argLine></argLine>
 	</properties>
 


### PR DESCRIPTION
## Summary
Upgrades Java from version 23 to 25 in all Maven projects.

## Changes
Updated Java version in 70 Maven project pom.xml files
* Standalone projects (14): maven.compiler.source and maven.compiler.target properties
* Spring Boot projects (56): java.version property

Updated JaCoCo from 0.8.12 to 0.8.13 in 5 projects
* Required for Java 25 compatibility (class file major version 69)

## Scope
* All sections: 1.x (standalone), 2.x, 3.x, 4.x (Spring Boot)
* Total projects: 70

## Testing
* All 70 Maven projects compiled successfully with Java 25
* All 70 Maven projects passed their unit tests

## Compatibility
* Spring Boot 3.5.9 compatible with Java 25
* JUnit 6.0.1 compatible with Java 25
* JaCoCo 0.8.13 supports Java 25
* No code changes required for this upgrade